### PR TITLE
[RFC] Cleanup & Improve Algolia indexing

### DIFF
--- a/src/drivers/json.js
+++ b/src/drivers/json.js
@@ -1,3 +1,4 @@
+import Bluebird from 'bluebird';
 import fs from 'file-system';
 
 export function init(fileName) {}
@@ -6,7 +7,7 @@ export function write(fileName, content) {
     return fs.writeFileSync(`./drivers-output/json/${fileName}.json`, JSON.stringify(content), 'utf8');
 }
 
-export function clear() {}
+export function clear() { return Bluebird.resolve(); }
 
 export default {
     init,

--- a/src/drivers/json.js
+++ b/src/drivers/json.js
@@ -6,7 +6,10 @@ export function write(fileName, content) {
     return fs.writeFileSync(`./drivers-output/json/${fileName}.json`, JSON.stringify(content), 'utf8');
 }
 
+export function clear() {}
+
 export default {
     init,
-    write
+    write,
+    clear
 };

--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,12 @@ const {
     DEBUG
 } = process.env;
 
+const SelectedDriver = drivers[DRIVER];
 
 // Initialise driver
-drivers[DRIVER].init('modules');
-drivers[DRIVER].init('classes');
-drivers[DRIVER].init('methods');
+SelectedDriver.init('modules');
+SelectedDriver.init('classes');
+SelectedDriver.init('methods');
 
 // Load ember.json which includes all available ember versions.
 readTmpFileAsync('rev-index/ember.json')
@@ -107,9 +108,9 @@ function writeToDriver(versionObject) {
 
     // Wait for all promises to complete before continuing
     return Bluebird.all([
-        drivers[DRIVER].write('modules', versionObject.publicModules),
-        drivers[DRIVER].write('classes', versionObject.publicClasses),
-        drivers[DRIVER].write('methods', versionObject.methods)
+        SelectedDriver.write('modules', versionObject.publicModules),
+        SelectedDriver.write('classes', versionObject.publicClasses),
+        SelectedDriver.write('methods', versionObject.methods)
     ]);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 require('dotenv').config();
 
+import Bluebird from 'bluebird';
 import logger from 'src/utils/logger';
 import drivers from 'src/drivers';
 import { readTmpFile, readTmpFileAsync } from 'src/utils/fs';
@@ -9,6 +10,7 @@ const {
     DRIVER,
     DEBUG
 } = process.env;
+
 
 // Initialise driver
 drivers[DRIVER].init('modules');
@@ -103,9 +105,12 @@ function mapDataForVersion(versionObject) {
 function writeToDriver(versionObject) {
     logger.logGreen(`version: ${versionObject.version.data.id}, public classes: ${versionObject.publicClasses.length}, public modules: ${versionObject.publicModules.length}, methods: ${versionObject.methods.length}`);
 
-    drivers[DRIVER].write('modules', versionObject.publicModules);
-    drivers[DRIVER].write('classes', versionObject.publicClasses);
-    drivers[DRIVER].write('methods', versionObject.methods);
+    // Wait for all promises to complete before continuing
+    return Bluebird.all([
+        drivers[DRIVER].write('modules', versionObject.publicModules),
+        drivers[DRIVER].write('classes', versionObject.publicClasses),
+        drivers[DRIVER].write('methods', versionObject.methods)
+    ]);
 }
 
 // Handle errors

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,8 @@ SelectedDriver.init('methods');
 readTmpFileAsync('rev-index/ember.json')
 // Extract available versions
 .then(emberJson => emberJson.meta.availableVersions)
+// Clear the driver contents
+.tap(clearDriver)
 // Grab the json file of each ember version
 .map(readIndexFileForVersion)
 // Fetch all public modules and public classes
@@ -111,6 +113,19 @@ function writeToDriver(versionObject) {
         SelectedDriver.write('modules', versionObject.publicModules),
         SelectedDriver.write('classes', versionObject.publicClasses),
         SelectedDriver.write('methods', versionObject.methods)
+    ]);
+}
+
+/**
+ * Clears the driver indices
+ *
+ * @returns {Promise}       - Promise with all drivers cleared.
+ */
+function clearDriver() {
+    return Bluebird.all([
+        SelectedDriver.clear('modules'),
+        SelectedDriver.clear('classes'),
+        SelectedDriver.clear('methods')
     ]);
 }
 


### PR DESCRIPTION
**Solves #1**

**tldr**
This pull request does a number of improvements on the way the indexing is handled.

- [x] Improve code readability & code documentation
- [x] Clears the Algolia index before indexing, to avoid doing it manually
- [x] Use promises instead of callbacks when adding objects to Algolia

**For the future;**

The ideal solution to avoid search downtime, would be to avoid clearing the index before reindexing. A "_tmp" index can be created during the indexing operation, and once the indexing is complete it can be renamed.

The reason we cannot do this yet, is that we are currently just over 50% of our records quota, so creating a new index would mean we will go over our limit, causing the indexing operation to stop.