### PR TITLE
Add guides option (erroneously api), add dist to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 build
 drivers-output
+dist

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Guides json files are currently not stored somewhere, because they are built on 
 To Generate the JSON files locally, clone [guides-app](https://github.com/ember-learn/guides-app), and run `ember build`.
 
 Once generated, use the following command to reindex algolia:
-`yarn start -p api`
+`yarn start -p guides`
 
 
 ## .env variables


### PR DESCRIPTION
the readme said to run `yarn start -p api` for guides.  Don't thinks that's right.  Also, adding the dist file created by build to gitignore so not inadvertantly checked in.