### PR TITLE
Remove since tag, get version from project-version relationship

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -162,7 +162,7 @@ function extractMethodsFromClasses(classes) {
       currentClass.data.attributes.methods
         .reduce((classMethods, currentMethod) => {
           // Transform the current method and push on to methods.
-          classMethods.push(schemas.methodSchema(currentMethod))
+          classMethods.push(schemas.methodSchema(currentMethod, currentClass))
           return classMethods
         }, [])
         // Merge all methods of all classes into a single array
@@ -187,7 +187,7 @@ function extractStaticFunctionsFromModules(modules) {
 
     return moduleStaticFunctions
       .reduce((moduleStaticFunctions, currentStaticFunction) => {
-        moduleStaticFunctions.push(schemas.methodSchema(currentStaticFunction))
+        moduleStaticFunctions.push(schemas.methodSchema(currentStaticFunction, currentModule))
         return moduleStaticFunctions
       }, [])
       .concat(methods)

--- a/lib/schemas/class.js
+++ b/lib/schemas/class.js
@@ -6,6 +6,8 @@
 export default function classSchema(classObj) {
   const data = classObj.data
   const attributes = data.attributes
+  const versionId = data.relationships['project-version'].data.id;
+  const version = versionId.substring(versionId.lastIndexOf('-')+1);
 
   return {
     id: data.id,
@@ -14,8 +16,7 @@ export default function classSchema(classObj) {
     namespace: attributes.namespace,
     _tags: [
       `module:${attributes.module}`,
-      `version:${attributes.version}`,
-      `since:${attributes.since}`
+      `version:${version}`
     ]
   }
 }

--- a/lib/schemas/method.js
+++ b/lib/schemas/method.js
@@ -3,7 +3,10 @@
  * @param   {Object} method     - An object with the method information.
  * @returns {Object}            - Transformed object
  */
-export default function methodSchema(method) {
+export default function methodSchema(method, versioned) {
+  let versionId = versioned.data.relationships['project-version'].data.id;
+  let version = versionId.substring(versionId.lastIndexOf('-')+1);
+
   return {
     file: method.file,
     line: method.line,
@@ -17,8 +20,7 @@ export default function methodSchema(method) {
 
     _tags: [
       `module:${method.module}`,
-      `version:${method.version}`,
-      `since:${method.since}`
+      `version:${version}`
     ],
 
     hierarchy: {

--- a/lib/schemas/module.js
+++ b/lib/schemas/module.js
@@ -6,12 +6,16 @@
 export default function moduleSchema(module) {
   const data = module.data
   const attributes = data.attributes
-
+  let versionId = data.relationships['project-version'].data.id;
+  let version = versionId.substring(versionId.lastIndexOf('-')+1);
   return {
     id: data.id,
     name: attributes.name,
     submodules: attributes.submodules,
     namespaces: attributes.namespaces,
-    _tags: [`module:${attributes.name}`, `version:${attributes.version}`]
+    _tags: [
+      `module:${attributes.name}`,
+      `version:${version}`
+    ]
   }
 }


### PR DESCRIPTION
Since is no longer guaranteed to be around, and also we are not sticking the version attribute everywhere like we were before, so updated script to fetch version from the "project-version" relationship, and to not tag since, since we aren't using it from the api client anyway.