### PR TITLE
Fix failures to find most recently added version index object

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -62,7 +62,12 @@ async function processDocs(driver, project) {
 
     await driver.write(
       'versions',
-      [{ id: project, name: project, versions }],
+      [{ 
+        id: project, 
+        name: project,
+        index_date_timestamp: Date.now(), 
+        versions 
+      }],
       project
     )
   } catch (err) {

--- a/lib/drivers/algolia.js
+++ b/lib/drivers/algolia.js
@@ -56,7 +56,11 @@ async function getPreviouslyIndexedVersions(projectName) {
     return []
   }
 
-  let hit = hits.find(hit => hit.name === projectName)
+  let hit = hits.filter(hit => (hit.name === projectName) && hit.index_date_timestamp)
+                .sort(function (a, b) {
+                  return a.index_date_timestamp - b.index_date_timestamp;
+                })
+                .pop()
 
   if (!hit) {
     return []


### PR DESCRIPTION
We started to experience significant churn in the processing of `json-api-docs` around the 25th/26th of June 2020. Every time the scheduler on Heroku was run (which was every hour) these scripts processed certain versions of Ember/Ember Data which had already been processed.

This extra processing caused us to go over our operations quota for Algolia. After contact w/ Algolia support and getting the limits raised, we turned the frequency of the scheduler down to 1x/day from 1x/hour while we worked on this solution.

The above-referenced bug was caused by reliance on the numerical hierarchy of Algolia's self-assigned `objectID`'s. It seems that Algolia moved to a different set of numbers of `objectID`'s and this broke our reliance on the highest `objectID` being the most recently added object. 

As a result, these scripts were constantly finding an older index object (which contains a list of ember versions as an array) that did not include certain Ember/Ember Data versions and needlessly re-processed the related `json-api-docs` for those missing versions.

This PR seeks to break that reliance and introduce a datetime stamp field on our version index objects which can be used to find the most recently added object in a more deterministic way. 

Separately (manually through the Algolia dashboard), we have introduced this datetime stamp field and populated it on the current most recent object in the version index.