### PR TITLE
add script for deleting tags

### DIFF
--- a/index-delete.js
+++ b/index-delete.js
@@ -1,0 +1,38 @@
+import AlgoliaSearch from 'algoliasearch';
+
+import 'dotenv/config'
+
+let client = null;
+let index = null;
+
+const { ALGOLIA_APP_ID, ALGOLIA_ADMIN_KEY } = process.env
+
+function init(indexName) {
+  if (!client) client = AlgoliaSearch(ALGOLIA_APP_ID, ALGOLIA_ADMIN_KEY);
+
+  return client.initIndex(indexName);
+}
+
+const params = {
+  "facets": [
+    "version",
+   ],
+  "facetFilters": [
+    [
+     "_tags:version:5.4.0"
+    ]
+  ],
+};
+
+index = init('methods');
+
+// index.search('', params).then((results) => {
+//   const {hits} = results;
+//   console.log(hits.length, results);
+// }).catch(console.log);
+
+
+index.deleteBy('', params).then((results) => {
+  const {hits} = results;
+  console.log(hits, results);
+}).catch(console.log);


### PR DESCRIPTION
This was useful when we identified some issues and we needed to delete tags from the algolia index. 

However, the operations in this script require a different version of the algolia library than the main indexing script so we'll need to reconcile this difference before merging this work.