### PR TITLE
Update README to reflect new setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,12 @@
 # Algolia API docs indexing script
 
-## Getting started
-
-### Setup
-
 1. `cp .env.example .env` - Copy the example environment configuration
-2. Update the Algolia .env variables and path to the root of the generated API docs (only needed for populating indexes. use the `-j` flag to write to disk during development)
-3. `yarn install` - Install dependencies
-
-### Indexing API
-
-Use any valid AWS tokens to setup the `AWS_ACCESS_KEY` & `AWS_SECRET_KEY` to download the json api docs.
-
-Use the following command to re-index algolia:
-`yarn start`
+2. Update the Algolia .env variables (these credentials are in the Ember CLI 1Password)
+3. `npm install` - Install dependencies
+4. Ensure you have [ember-api-docs-data](https://github.com/ember-learn/ember-api-docs-data) cloned in a location on your machine alongside this project as a sibling and pull the latest changes
+5. Use the following command to re-index Algolia: `npm start`
 
 ## .env variables
 
 1. `ALGOLIA_APP_ID` - The Algolia application ID, found in "API Keys" section of the Algolia dashboard
 2. `ALGOLIA_ADMIN_KEY` - The Algolia admin key, found in "API Keys" section of the Algolia dashboard
-3. `AWS_ACCESS_KEY` & `AWS_SECRET_KEY` - Any valid AWS token that can be used to read our public json docs


### PR DESCRIPTION
- we no longer use AWS 
- we use ember-api-docs-data
- this updates the README to reflect the correct steps to run this indexing script